### PR TITLE
Abstracting over both the element of the box and the box itself

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ project/plugins/project/
 .lib/
 .idea/
 .idea_modules/
+.sc

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ sbt "runMain example.Concept"
 
 | Problem | Solution |
 | ------------- | ------------- |
+| Abstracting over both the element of the box and the box itself | [Type constructor polymorphism](https://github.com/mario-galic/scala-cats-examples/blob/master/src/main/scala/example/TypeConstructor.scala) |
 | Polymorphic implementation of general function without using class inheritance | [Type class](https://github.com/mario-galic/scala-cats-examples/blob/master/src/main/scala/example/TypeClass.scala) |
 | Avoid polluting function signatures with configuration parameter | [Kleisli (Reader)](https://github.com/mario-galic/scala-cats-examples/blob/master/src/main/scala/example/Kleisli.scala) |
 | Make obvious impure parts of the program | [IO](https://github.com/mario-galic/scala-cats-examples/blob/master/src/main/scala/example/Io.scala) |

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ ThisBuild / version          := "0.1.0-SNAPSHOT"
 ThisBuild / organization     := "com.example"
 ThisBuild / organizationName := "example"
 
-val catsVersion = "2.0.0-M3"
+val catsVersion = "2.0.0"
 
 lazy val root = (project in file("."))
   .settings(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.12

--- a/src/main/scala/example/TypeConstructor.scala
+++ b/src/main/scala/example/TypeConstructor.scala
@@ -1,0 +1,45 @@
+package example
+
+/**
+ * Problem: Abstracting over both the element of the box and the box itself
+ * Tutorial: https://stackoverflow.com/a/62366781/5205022
+ * Doc: http://adriaanm.github.io/research/2010/10/06/new-in-scala-2.8-type-constructor-inference/
+ */
+object TypeConstructor extends App {
+  trait Zar         // Zar is proper type                            - shape *               - box       of chocolates
+  trait Foo[A]      // Foo is type constructor of 1st order kind     - shape * -> *          - box       of things
+  trait Bar[F[_]]   // Bar is type constructor of higher order kind  - shape (* -> *) -> *   - container of things
+
+  def f[A] = println("f takes proper type argument of * shape")
+  f[Int]
+  f[Zar]
+  f[List[Int]]
+  f[Tuple2[Int, String]]
+  f[Function3[Int, Double, Char, String]]
+  // f[List]                                   // error because actual * -> * shape does not fit expected * shape
+  // f[Foo]                                    // error because actual * -> * shape does not fit expected * shape
+  // f[Bar]                                    // error because actual (* -> *) -> * shape does not fit expected * shape
+  // f[cats.Functor]                           // error because actual (* -> *) -> * shape does not fit expected * shape
+
+  def g[F[_]] = println("g takes type constructor type argument of * -> * shape")
+  // g[Int]                                    // error because actual * shape does not fit expected * -> * shape
+  // g[Zar]                                    // error because actual * shape does not fit expected * -> * shape
+  // g[List[Int]]                              // error because actual * shape does not fit expected * -> * shape
+  // g[Tuple2[Int, String]]                    // error because actual * shape does not fit expected * -> * shape
+  // g[Function3[Int, Double, Char, String]]   // error because actual * shape does not fit expected * -> * shape
+  g[List]
+  g[Foo]
+  // g[Bar]                                    // error because actual (* -> *) -> * shape does not fit expected * -> * shape
+  // g[cats.Functor]                           // error because actual (* -> *) -> * shape does not fit expected * -> * shape
+
+  def h[F[G[_]]] = println("h takes type constructor type argument of (* -> *) -> * shape")
+  // h[Int]                                    // error because actual * shape does not fit expected (* -> *) -> * shape
+  // h[Zar]                                    // error because actual * shape does not fit expected (* -> *) -> * shape
+  // h[List[Int]]                              // error because actual * shape does not fit expected (* -> *) -> * shape
+  // h[Tuple2[Int, String]]                    // error because actual * shape does not fit expected (* -> *) -> * shape
+  // h[Function3[Int, Double, Char, String]]   // error because actual * shape does not fit expected (* -> *) -> * shape
+  // h[List]                                   // error because actual * -> * shape does not fit expected  (* -> *) -> * shape
+  // h[Foo]                                    // error because actual * -> * shape does not fit expected  (* -> *) -> * shape
+  h[Bar]
+  h[cats.Functor]                              // error because actual (* -> *) -> * shape does not fit expected * -> * shape
+}


### PR DESCRIPTION
* Problem: Abstracting over both the element of the box and the box itself
* Tutorial: https://stackoverflow.com/a/62366781/5205022
* Doc: http://adriaanm.github.io/research/2010/10/06/new-in-scala-2.8-type-constructor-inference/

Further references

- https://users.scala-lang.org/t/distinguish-first-order-type-and-type-constructors/687
- https://typelevel.org/blog/2016/08/21/hkts-moving-forward.html
- Type Constructor Polymorphism for Scala: Theory and Practice, Adriaan MOORS